### PR TITLE
Adds call to Braze SDK Metadata field

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 github "tealium/tealium-swift" ~> 2.1
-binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_core.json" ~> 3.2
+binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk.json" ~> 4.4.1
+github "SDWebImage/SDWebImage" ~> 5.12

--- a/Sources/BrazeInstance.swift
+++ b/Sources/BrazeInstance.swift
@@ -128,7 +128,11 @@ public class BrazeInstance: BrazeCommand, BrazeCommandNotifier {
             Appboy.start(withApiKey: apiKey, in: application as? UIApplication ?? UIApplication.shared, withLaunchOptions: launchOptions, withAppboyOptions: appboyOptions)
         }
     }
-    
+
+    public func addSdkMetadata(_ metadata: ABKSdkMetadata) {
+      Appboy.sharedInstance()?.addSdkMetadata([metadata])
+    }
+
     public func logSingleLocation() {
            Appboy.sharedInstance()?.locationManager.logSingleLocation()
     }

--- a/Sources/BrazeRemoteCommand.swift
+++ b/Sources/BrazeRemoteCommand.swift
@@ -97,6 +97,7 @@ public class BrazeRemoteCommand: RemoteCommand {
                     return brazeInstance.initializeBraze(apiKey: apiKey, application: UIApplication.shared, launchOptions: nil, appboyOptions: appboyOptions)
                 }
                 brazeInstance.initializeBraze(apiKey: apiKey, application: UIApplication.shared, launchOptions: launchOptions, appboyOptions: appboyOptions)
+                brazeInstance.addSdkMetadata(.tealium)
             case .userIdentifier:
                 guard let userIdentifier = payload[BrazeConstants.Keys.userIdentifier] as? String else {
                     return

--- a/TealiumBraze.podspec
+++ b/TealiumBraze.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
     s.ios.dependency 'tealium-swift/Core', '~> 2.1'
     s.ios.dependency 'tealium-swift/RemoteCommands', '~> 2.1'
     s.ios.dependency 'tealium-swift/TagManagement', '~> 2.1'
-    s.ios.dependency 'Appboy-iOS-SDK', '~> 3.2'
+    s.ios.dependency 'Appboy-iOS-SDK', '~> 4.4.1'
 
 end

--- a/TealiumBraze.xcodeproj/project.pbxproj
+++ b/TealiumBraze.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -15,8 +15,6 @@
 		CF3277C22522A38900696BB4 /* BrazeRemoteCommand.swift in Headers */ = {isa = PBXBuildFile; fileRef = CFA79626251D40DC004D4FA4 /* BrazeRemoteCommand.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		CF3277C32522A38900696BB4 /* BrazeInstance.swift in Headers */ = {isa = PBXBuildFile; fileRef = CFA79627251D40DC004D4FA4 /* BrazeInstance.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		CF3277C42522A38900696BB4 /* DateConverter.swift in Headers */ = {isa = PBXBuildFile; fileRef = CFA79624251D40DC004D4FA4 /* DateConverter.swift */; settings = {ATTRIBUTES = (Public, ); }; };
-		CF4728C524194D4800F7B604 /* Appboy_iOS_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF4917F236CC18C00CA46EC /* Appboy_iOS_SDK.framework */; };
-		CF4728C624194D4800F7B604 /* Appboy_iOS_SDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF4917F236CC18C00CA46EC /* Appboy_iOS_SDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CFA795DC251D1709004D4FA4 /* TealiumRemoteCommands.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF49185236CC19C00CA46EC /* TealiumRemoteCommands.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CFA795DE251D1709004D4FA4 /* TealiumTagManagement.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF49187236CC1AE00CA46EC /* TealiumTagManagement.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CFA795E0251D1709004D4FA4 /* TealiumCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4BF49181236CC19400CA46EC /* TealiumCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -28,6 +26,10 @@
 		CFD61FE02389F78A006DFDDB /* TealiumBraze.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B8DB65C22E622E00074687A /* TealiumBraze.framework */; };
 		CFD62044238C7F6F006DFDDB /* TealiumRemoteCommands.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BF49185236CC19C00CA46EC /* TealiumRemoteCommands.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CFD62045238C7F6F006DFDDB /* TealiumCore.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4BF49181236CC19400CA46EC /* TealiumCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D58C2046276011C00063FBFA /* SDWebImage.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58C2045276011C00063FBFA /* SDWebImage.xcframework */; };
+		D58C2047276011C00063FBFA /* SDWebImage.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D58C2045276011C00063FBFA /* SDWebImage.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D58C2049276011EB0063FBFA /* Appboy_iOS_SDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D58C2048276011EB0063FBFA /* Appboy_iOS_SDK.xcframework */; };
+		D58C204A276011EB0063FBFA /* Appboy_iOS_SDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D58C2048276011EB0063FBFA /* Appboy_iOS_SDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,9 +49,10 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				D58C204A276011EB0063FBFA /* Appboy_iOS_SDK.xcframework in Embed Frameworks */,
 				CFA795DE251D1709004D4FA4 /* TealiumTagManagement.framework in Embed Frameworks */,
+				D58C2047276011C00063FBFA /* SDWebImage.xcframework in Embed Frameworks */,
 				CFA795DC251D1709004D4FA4 /* TealiumRemoteCommands.framework in Embed Frameworks */,
-				CF4728C624194D4800F7B604 /* Appboy_iOS_SDK.framework in Embed Frameworks */,
 				CFA795E0251D1709004D4FA4 /* TealiumCore.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -75,7 +78,6 @@
 		4B8DB66022E622E00074687A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4BCDE3E722E6272D000A501B /* MockBrazeInstance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockBrazeInstance.swift; sourceTree = "<group>"; };
 		4BCDE3E822E6272D000A501B /* BrazeInstanceWebviewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrazeInstanceWebviewTests.swift; sourceTree = "<group>"; };
-		4BF4917F236CC18C00CA46EC /* Appboy_iOS_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Appboy_iOS_SDK.framework; path = Carthage/Build/iOS/Appboy_iOS_SDK.framework; sourceTree = "<group>"; };
 		4BF49181236CC19400CA46EC /* TealiumCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TealiumCore.framework; path = Carthage/Build/iOS/TealiumCore.framework; sourceTree = "<group>"; };
 		4BF49183236CC19800CA46EC /* TealiumDelegate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TealiumDelegate.framework; path = Carthage/Build/iOS/TealiumDelegate.framework; sourceTree = "<group>"; };
 		4BF49185236CC19C00CA46EC /* TealiumRemoteCommands.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TealiumRemoteCommands.framework; path = Carthage/Build/iOS/TealiumRemoteCommands.framework; sourceTree = "<group>"; };
@@ -88,6 +90,9 @@
 		CFA79625251D40DC004D4FA4 /* BrazeConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrazeConstants.swift; sourceTree = "<group>"; };
 		CFA79626251D40DC004D4FA4 /* BrazeRemoteCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrazeRemoteCommand.swift; sourceTree = "<group>"; };
 		CFA79627251D40DC004D4FA4 /* BrazeInstance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrazeInstance.swift; sourceTree = "<group>"; };
+		D58C2042275EC3400063FBFA /* Appboy_iOS_SDK_core.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Appboy_iOS_SDK_core.xcframework; path = Carthage/Build/Appboy_iOS_SDK_core.xcframework; sourceTree = "<group>"; };
+		D58C2045276011C00063FBFA /* SDWebImage.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SDWebImage.xcframework; path = Carthage/Build/SDWebImage.xcframework; sourceTree = "<group>"; };
+		D58C2048276011EB0063FBFA /* Appboy_iOS_SDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Appboy_iOS_SDK.xcframework; path = Carthage/Build/Appboy_iOS_SDK.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,7 +100,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CF4728C524194D4800F7B604 /* Appboy_iOS_SDK.framework in Frameworks */,
+				D58C2046276011C00063FBFA /* SDWebImage.xcframework in Frameworks */,
+				D58C2049276011EB0063FBFA /* Appboy_iOS_SDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,12 +163,14 @@
 		4BF4917E236CC18C00CA46EC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D58C2048276011EB0063FBFA /* Appboy_iOS_SDK.xcframework */,
+				D58C2045276011C00063FBFA /* SDWebImage.xcframework */,
+				D58C2042275EC3400063FBFA /* Appboy_iOS_SDK_core.xcframework */,
 				4B38232C236CDDBF00C3AE37 /* SDWebImage.framework */,
 				4BF49187236CC1AE00CA46EC /* TealiumTagManagement.framework */,
 				4BF49185236CC19C00CA46EC /* TealiumRemoteCommands.framework */,
 				4BF49183236CC19800CA46EC /* TealiumDelegate.framework */,
 				4BF49181236CC19400CA46EC /* TealiumCore.framework */,
-				4BF4917F236CC18C00CA46EC /* Appboy_iOS_SDK.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/TealiumBrazeExample/Podfile.lock
+++ b/TealiumBrazeExample/Podfile.lock
@@ -1,33 +1,33 @@
 PODS:
-  - Appboy-iOS-SDK (3.29.0):
-    - Appboy-iOS-SDK/UI (= 3.29.0)
-  - Appboy-iOS-SDK/ContentCards (3.29.0):
+  - Appboy-iOS-SDK (4.4.1):
+    - Appboy-iOS-SDK/UI (= 4.4.1)
+  - Appboy-iOS-SDK/ContentCards (4.4.1):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/Core (3.29.0)
-  - Appboy-iOS-SDK/InAppMessage (3.29.0):
+  - Appboy-iOS-SDK/Core (4.4.1)
+  - Appboy-iOS-SDK/InAppMessage (4.4.1):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/NewsFeed (3.29.0):
+  - Appboy-iOS-SDK/NewsFeed (4.4.1):
     - Appboy-iOS-SDK/Core
     - SDWebImage (< 6, >= 5.8.2)
-  - Appboy-iOS-SDK/UI (3.29.0):
+  - Appboy-iOS-SDK/UI (4.4.1):
     - Appboy-iOS-SDK/ContentCards
     - Appboy-iOS-SDK/Core
     - Appboy-iOS-SDK/InAppMessage
     - Appboy-iOS-SDK/NewsFeed
-  - SDWebImage (5.9.3):
-    - SDWebImage/Core (= 5.9.3)
-  - SDWebImage/Core (5.9.3)
-  - tealium-swift/Core (2.1.0)
-  - tealium-swift/Lifecycle (2.1.0):
+  - SDWebImage (5.12.1):
+    - SDWebImage/Core (= 5.12.1)
+  - SDWebImage/Core (5.12.1)
+  - tealium-swift/Core (2.5.1)
+  - tealium-swift/Lifecycle (2.5.1):
     - tealium-swift/Core
-  - tealium-swift/RemoteCommands (2.1.0):
+  - tealium-swift/RemoteCommands (2.5.1):
     - tealium-swift/Core
-  - tealium-swift/TagManagement (2.1.0):
+  - tealium-swift/TagManagement (2.5.1):
     - tealium-swift/Core
   - TealiumBraze (2.0.0):
-    - Appboy-iOS-SDK (~> 3.2)
+    - Appboy-iOS-SDK (~> 4.4)
     - tealium-swift/Core (~> 2.1)
     - tealium-swift/RemoteCommands (~> 2.1)
     - tealium-swift/TagManagement (~> 2.1)
@@ -47,11 +47,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Appboy-iOS-SDK: 1852bad2912f0eb59701b1a53aaad7f03b75d716
-  SDWebImage: a31ee8e90a97303529e03fb0c333eae0eacb88e9
-  tealium-swift: a670c2c6f3e7e5d775d9507387e8858a8541e526
-  TealiumBraze: e8a87520713fd99c016555be10849887d18cfca7
+  Appboy-iOS-SDK: 541a839e91a9176ca5c5431375b770a732f8da59
+  SDWebImage: 4dc3e42d9ec0c1028b960a33ac6b637bb432207b
+  tealium-swift: a7c0f2b6bff641abb1818efbcf22598c99af0517
+  TealiumBraze: a94f96d0a34208ad810c916f9c6debf48fc3e804
 
 PODFILE CHECKSUM: c8a9be1ccc2a80510f31ec918e56aea892cf5033
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.2

--- a/TealiumBrazeExample/TealiumBrazeExample/Info.plist
+++ b/TealiumBrazeExample/TealiumBrazeExample/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Braze</key>
+	<dict>
+		<key>LogLevel</key>
+		<string>0</string>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
- Updates to use Appboy_iOS_SDK ~> 4.4.1
  - Integrates the `.xcframeworks` associated with this version for the full SDK into the sample app
- Adds binding to `addSdkMetadata`, which is also automatically called after initializing Braze

There were some compilation issues in the sample app around TealiumCore so I was unable to test end-to-end. Since the sample app now has debug logging, you can verify this change by checking that a request is sent with the field `"sdk_metadata":` and a code for Tealium as the value