### PR TITLE
[MT-2072] Update Braze Dependency to 17.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "tealium/tealium-swift" ~> 2.18
-binary "https://raw.githubusercontent.com/Tealium/tealium-ios-braze-remote-command/main/braze.json" ~> 14.0
+binary "https://raw.githubusercontent.com/Tealium/tealium-ios-braze-remote-command/main/braze.json" ~> 17.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://raw.githubusercontent.com/Tealium/tealium-ios-braze-remote-command/main/braze.json" "14.0.1"
+binary "https://raw.githubusercontent.com/Tealium/tealium-ios-braze-remote-command/main/braze.json" "17.0.0"
 github "tealium/tealium-swift" "2.18.2"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braze-inc/braze-swift-sdk",
         "state": {
           "branch": null,
-          "revision": "e31907eaa0dbd151dc2e6826de66cc494242ba60",
-          "version": "14.0.1"
+          "revision": "ff893d560eab7b5e5657c3617daf07e2e0e7c74b",
+          "version": "17.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/tealium/tealium-swift", .upToNextMajor(from: "2.18.0")),
-        .package(url: "https://github.com/braze-inc/braze-swift-sdk", .upToNextMajor(from: "14.0.0"))
+        .package(url: "https://github.com/braze-inc/braze-swift-sdk", .upToNextMajor(from: "17.0.0"))
     ],
     targets: [
         .target(

--- a/Sources/BrazeConstants.swift
+++ b/Sources/BrazeConstants.swift
@@ -14,7 +14,7 @@ public enum BrazeConstants {
     static let separator: Character = ","
     static let commandId = "braze"
     static let description = "Braze Remote Command"
-    static let version = "3.6.0"
+    static let version = "3.7.0"
     
     enum Commands: String {
         case initialize = "initialize"

--- a/TealiumBraze.podspec
+++ b/TealiumBraze.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
     # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
     s.name         = "TealiumBraze"
     s.module_name  = "TealiumBraze"
-    s.version      = "3.6.0"
+    s.version      = "3.7.0"
     s.summary      = "Tealium Swift and Braze integration"
     s.description  = <<-DESC
     Tealium's integration with Braze for iOS.
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     # ――― Dependencies ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
     s.ios.dependency 'tealium-swift/Core', '~> 2.18'
     s.ios.dependency 'tealium-swift/RemoteCommands', '~> 2.18'
-    s.ios.dependency 'BrazeKit', '~> 14.0'
+    s.ios.dependency 'BrazeKit', '~> 17.0'
     s.static_framework = true
 
 end

--- a/TealiumBrazeExample/Podfile.lock
+++ b/TealiumBrazeExample/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
-  - BrazeKit (11.9.0)
-  - BrazeLocation (11.9.0):
-    - BrazeKit (= 11.9.0)
-  - tealium-swift/Core (2.16.0)
-  - tealium-swift/Lifecycle (2.16.0):
+  - BrazeKit (17.0.0)
+  - BrazeLocation (17.0.0):
+    - BrazeKit (= 17.0.0)
+  - tealium-swift/Core (2.18.3)
+  - tealium-swift/Lifecycle (2.18.3):
     - tealium-swift/Core
-  - tealium-swift/RemoteCommands (2.16.0):
+  - tealium-swift/RemoteCommands (2.18.3):
     - tealium-swift/Core
-  - tealium-swift/TagManagement (2.16.0):
+  - tealium-swift/TagManagement (2.18.3):
     - tealium-swift/Core
-  - TealiumBraze (3.5.0):
-    - BrazeKit (~> 11.0)
-    - tealium-swift/Core (~> 2.16)
-    - tealium-swift/RemoteCommands (~> 2.16)
+  - TealiumBraze (3.7.0):
+    - BrazeKit (~> 17.0)
+    - tealium-swift/Core (~> 2.18)
+    - tealium-swift/RemoteCommands (~> 2.18)
 
 DEPENDENCIES:
   - BrazeLocation
@@ -31,11 +31,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BrazeKit: b21335426470a4e80b0a21fdeec69bdbe6852222
-  BrazeLocation: 03848efc27e835646013aa297868707111a1e715
-  tealium-swift: b288efd08c4721cf0b70dcf1149f055fbaec977b
-  TealiumBraze: ff71a357bf661e5eb344b8ef80303471749faca9
+  BrazeKit: 79cea5ad1686252af497361c0bb3c888ee1746af
+  BrazeLocation: f26f6b2cc275b91d3ed1767cb75abfb9fc102283
+  tealium-swift: c9137d28fe7f92f89622e66403ec75a9c0892def
+  TealiumBraze: 799833a140da1f254fa8900f5dbf988921e24574
 
 PODFILE CHECKSUM: bd36620a6237490c846dcfc61142c9bc2791390d
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/braze.json
+++ b/braze.json
@@ -1,4 +1,7 @@
 {
+  "17.0.0": "https://github.com/braze-inc/braze-swift-sdk/releases/download/17.0.0/BrazeKit.zip",
+  "16.0.0": "https://github.com/braze-inc/braze-swift-sdk/releases/download/16.0.0/BrazeKit.zip",
+  "15.2.0": "https://github.com/braze-inc/braze-swift-sdk/releases/download/15.2.0/BrazeKit.zip",
   "14.0.1": "https://github.com/braze-inc/braze-swift-sdk/releases/download/14.0.1/BrazeKit.zip",
   "11.9.0":"https://github.com/braze-inc/braze-swift-sdk/releases/download/11.9.0/BrazeKit.zip",
   "10.3.1":"https://github.com/braze-inc/braze-swift-sdk/releases/download/10.3.1/BrazeKit.zip",


### PR DESCRIPTION
## What
Bump Braze Swift SDK 14.x -> 17.0.0 (`Package.swift`, `TealiumBraze.podspec`, `Cartfile`, `braze.json`), regenerate lockfiles (`Package.resolved`, `Cartfile.resolved`, example `Podfile.lock`), bump lib version 3.6.0 -> 3.7.0.

## Why
Enables the eCommerce recommended events API added in Braze 15.x (`Braze.logEcommerceEvent(_:)`), wired up separately in MT-2073. Checked 15.x-17.x breaking changes (Banner `onDismiss`, ContentCards behavior, `changeUser`/`wipeData` threading) against this repo's usage -- none apply. Existing `logPurchase` tests unmodified.