### PR TITLE
[MT-2073] Fix scroll in events page

### DIFF
--- a/TealiumBrazeExample/TealiumBrazeExample/Main.storyboard
+++ b/TealiumBrazeExample/TealiumBrazeExample/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3X4-F0-9RA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3X4-F0-9RA">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,14 +17,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xIM-oG-RWP">
-                                <rect key="frame" x="362" y="44" width="36" height="30"/>
+                                <rect key="frame" x="362" y="88" width="36" height="30"/>
                                 <state key="normal" title="Send"/>
                                 <connections>
                                     <action selector="onSend:" destination="BYZ-38-t0r" eventType="touchUpInside" id="a2v-aj-GqU"/>
                                 </connections>
                             </button>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="abu-MP-CIH">
-                                <rect key="frame" x="20" y="766" width="374" height="32"/>
+                                <rect key="frame" x="20" y="732" width="374" height="32"/>
                                 <segments>
                                     <segment title="Male"/>
                                     <segment title="Female"/>
@@ -35,7 +35,7 @@
                                 </segments>
                             </segmentedControl>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="23" translatesAutoresizingMaskIntoConstraints="NO" id="Dib-Gm-vb9">
-                                <rect key="frame" x="16" y="44" width="326" height="433"/>
+                                <rect key="frame" x="16" y="88" width="326" height="433"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="First Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Rj2-ff-i6Q">
                                         <rect key="frame" x="0.0" y="0.0" width="326" height="34"/>
@@ -150,7 +150,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="62" translatesAutoresizingMaskIntoConstraints="NO" id="Ews-YP-hj8">
-                                <rect key="frame" x="16" y="94" width="382" height="124"/>
+                                <rect key="frame" x="16" y="138" width="382" height="124"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="69" translatesAutoresizingMaskIntoConstraints="NO" id="iob-nN-9FR">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="31"/>
@@ -193,7 +193,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EVQ-Ke-WTz">
-                                <rect key="frame" x="362" y="44" width="36" height="30"/>
+                                <rect key="frame" x="362" y="88" width="36" height="30"/>
                                 <state key="normal" title="Send"/>
                                 <connections>
                                     <action selector="onSend:" destination="E81-ra-M5B" eventType="touchUpInside" id="76L-5x-4JC"/>
@@ -230,122 +230,146 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="h7P-pY-Gdm">
-                                <rect key="frame" x="108" y="237" width="198" height="422"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A94-MG-WzW">
+                                <rect key="frame" x="0.0" y="88" width="414" height="691"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wPP-Wg-k6Y">
-                                        <rect key="frame" x="0.0" y="0.0" width="198" height="30"/>
-                                        <state key="normal" title="Log Event"/>
-                                        <connections>
-                                            <action selector="logEvent:" destination="1to-9j-H1z" eventType="touchUpInside" id="bLo-9Z-iPx"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5t4-hb-Et5">
-                                        <rect key="frame" x="0.0" y="56" width="198" height="30"/>
-                                        <state key="normal" title="Log Event With Properties"/>
-                                        <connections>
-                                            <action selector="logEventWithProperties:" destination="1to-9j-H1z" eventType="touchUpInside" id="UiC-WW-0U2"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0aH-sk-WXr">
-                                        <rect key="frame" x="0.0" y="112" width="198" height="30"/>
-                                        <state key="normal" title="Set Custom Attributes"/>
-                                        <connections>
-                                            <action selector="setCustomAttributes:" destination="1to-9j-H1z" eventType="touchUpInside" id="kIC-2B-6Hu"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uHE-Dm-8RO" userLabel="Unset Custom Attributes">
-                                        <rect key="frame" x="0.0" y="168" width="198" height="30"/>
-                                        <state key="normal" title="Unset Custom Attributes"/>
-                                        <connections>
-                                            <action selector="unsetCustomAttributes:" destination="1to-9j-H1z" eventType="touchUpInside" id="cfu-u8-uC7"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m9a-g9-xg8">
-                                        <rect key="frame" x="0.0" y="224" width="198" height="30"/>
-                                        <state key="normal" title="Increment Custom Attributes"/>
-                                        <connections>
-                                            <action selector="incrementCustomAttributes:" destination="1to-9j-H1z" eventType="touchUpInside" id="Zcy-WC-Qbe"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sk3-fp-0zh">
-                                        <rect key="frame" x="0.0" y="280" width="198" height="30"/>
-                                        <state key="normal" title="Log Purchase"/>
-                                        <connections>
-                                            <action selector="logPurchase:" destination="1to-9j-H1z" eventType="touchUpInside" id="2aI-pd-axQ"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lOg-2M-QMv">
-                                        <rect key="frame" x="0.0" y="336" width="198" height="30"/>
-                                        <state key="normal" title="Set User Location"/>
-                                        <connections>
-                                            <action selector="setLastKnownLocationWithSender:" destination="1to-9j-H1z" eventType="touchUpInside" id="yno-wn-ZcQ"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec1-pr-vw0">
-                                        <state key="normal" title="Log Product Viewed"/>
-                                        <connections>
-                                            <action selector="logProductViewed:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec1-ac-vw0"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec2-ca-add">
-                                        <state key="normal" title="Log Cart Updated (Add)"/>
-                                        <connections>
-                                            <action selector="logCartUpdatedAdd:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec2-ac-add"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec3-ca-rmv">
-                                        <state key="normal" title="Log Cart Updated (Remove)"/>
-                                        <connections>
-                                            <action selector="logCartUpdatedRemove:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec3-ac-rmv"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec4-ca-rpl">
-                                        <state key="normal" title="Log Cart Updated (Replace)"/>
-                                        <connections>
-                                            <action selector="logCartUpdatedReplace:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec4-ac-rpl"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec5-ck-out">
-                                        <state key="normal" title="Log Checkout Started"/>
-                                        <connections>
-                                            <action selector="logCheckoutStarted:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec5-ac-out"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec6-or-plc">
-                                        <state key="normal" title="Log Order Placed"/>
-                                        <connections>
-                                            <action selector="logOrderPlaced:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec6-ac-plc"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec7-or-cnl">
-                                        <state key="normal" title="Log Order Cancelled"/>
-                                        <connections>
-                                            <action selector="logOrderCancelled:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec7-ac-cnl"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec8-or-rfd">
-                                        <state key="normal" title="Log Order Refunded"/>
-                                        <connections>
-                                            <action selector="logOrderRefunded:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec8-ac-rfd"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOr-ie-Oge">
-                                        <rect key="frame" x="0.0" y="392" width="198" height="30"/>
-                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                        <state key="normal" title="Unknown Event"/>
-                                        <connections>
-                                            <action selector="logUnknownEvent:" destination="1to-9j-H1z" eventType="touchUpInside" id="h4o-WN-Y2f"/>
-                                        </connections>
-                                    </button>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="h7P-pY-Gdm">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="870"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wPP-Wg-k6Y">
+                                                <rect key="frame" x="173" y="0.0" width="68" height="30"/>
+                                                <state key="normal" title="Log Event"/>
+                                                <connections>
+                                                    <action selector="logEvent:" destination="1to-9j-H1z" eventType="touchUpInside" id="bLo-9Z-iPx"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5t4-hb-Et5">
+                                                <rect key="frame" x="117.66666666666669" y="56" width="179" height="30"/>
+                                                <state key="normal" title="Log Event With Properties"/>
+                                                <connections>
+                                                    <action selector="logEventWithProperties:" destination="1to-9j-H1z" eventType="touchUpInside" id="UiC-WW-0U2"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0aH-sk-WXr">
+                                                <rect key="frame" x="131" y="112" width="152" height="30"/>
+                                                <state key="normal" title="Set Custom Attributes"/>
+                                                <connections>
+                                                    <action selector="setCustomAttributes:" destination="1to-9j-H1z" eventType="touchUpInside" id="kIC-2B-6Hu"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uHE-Dm-8RO" userLabel="Unset Custom Attributes">
+                                                <rect key="frame" x="122.66666666666669" y="168" width="169" height="30"/>
+                                                <state key="normal" title="Unset Custom Attributes"/>
+                                                <connections>
+                                                    <action selector="unsetCustomAttributes:" destination="1to-9j-H1z" eventType="touchUpInside" id="cfu-u8-uC7"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m9a-g9-xg8">
+                                                <rect key="frame" x="108" y="224" width="198" height="30"/>
+                                                <state key="normal" title="Increment Custom Attributes"/>
+                                                <connections>
+                                                    <action selector="incrementCustomAttributes:" destination="1to-9j-H1z" eventType="touchUpInside" id="Zcy-WC-Qbe"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sk3-fp-0zh">
+                                                <rect key="frame" x="160" y="280" width="94" height="30"/>
+                                                <state key="normal" title="Log Purchase"/>
+                                                <connections>
+                                                    <action selector="logPurchase:" destination="1to-9j-H1z" eventType="touchUpInside" id="2aI-pd-axQ"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lOg-2M-QMv">
+                                                <rect key="frame" x="146" y="336" width="122" height="30"/>
+                                                <state key="normal" title="Set User Location"/>
+                                                <connections>
+                                                    <action selector="setLastKnownLocationWithSender:" destination="1to-9j-H1z" eventType="touchUpInside" id="yno-wn-ZcQ"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec1-pr-vw0">
+                                                <rect key="frame" x="138" y="392" width="138" height="30"/>
+                                                <state key="normal" title="Log Product Viewed"/>
+                                                <connections>
+                                                    <action selector="logProductViewed:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec1-ac-vw0"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec2-ca-add">
+                                                <rect key="frame" x="124.66666666666669" y="448" width="165" height="30"/>
+                                                <state key="normal" title="Log Cart Updated (Add)"/>
+                                                <connections>
+                                                    <action selector="logCartUpdatedAdd:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec2-ac-add"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec3-ca-rmv">
+                                                <rect key="frame" x="111" y="504" width="192" height="30"/>
+                                                <state key="normal" title="Log Cart Updated (Remove)"/>
+                                                <connections>
+                                                    <action selector="logCartUpdatedRemove:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec3-ac-rmv"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec4-ca-rpl">
+                                                <rect key="frame" x="111" y="560" width="192" height="30"/>
+                                                <state key="normal" title="Log Cart Updated (Replace)"/>
+                                                <connections>
+                                                    <action selector="logCartUpdatedReplace:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec4-ac-rpl"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec5-ck-out">
+                                                <rect key="frame" x="132" y="616" width="150" height="30"/>
+                                                <state key="normal" title="Log Checkout Started"/>
+                                                <connections>
+                                                    <action selector="logCheckoutStarted:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec5-ac-out"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec6-or-plc">
+                                                <rect key="frame" x="147" y="672" width="120" height="30"/>
+                                                <state key="normal" title="Log Order Placed"/>
+                                                <connections>
+                                                    <action selector="logOrderPlaced:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec6-ac-plc"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec7-or-cnl">
+                                                <rect key="frame" x="136.66666666666666" y="728" width="140.99999999999997" height="30"/>
+                                                <state key="normal" title="Log Order Cancelled"/>
+                                                <connections>
+                                                    <action selector="logOrderCancelled:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec7-ac-cnl"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ec8-or-rfd">
+                                                <rect key="frame" x="137" y="784" width="140" height="30"/>
+                                                <state key="normal" title="Log Order Refunded"/>
+                                                <connections>
+                                                    <action selector="logOrderRefunded:" destination="1to-9j-H1z" eventType="touchUpInside" id="ec8-ac-rfd"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOr-ie-Oge">
+                                                <rect key="frame" x="153.66666666666666" y="840" width="106.99999999999997" height="30"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="Unknown Event"/>
+                                                <connections>
+                                                    <action selector="logUnknownEvent:" destination="1to-9j-H1z" eventType="touchUpInside" id="h4o-WN-Y2f"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
-                            </stackView>
+                                <constraints>
+                                    <constraint firstItem="h7P-pY-Gdm" firstAttribute="trailing" secondItem="ZE1-1b-hch" secondAttribute="trailing" id="3SR-9e-nT1"/>
+                                    <constraint firstItem="h7P-pY-Gdm" firstAttribute="width" secondItem="PyD-MK-1En" secondAttribute="width" id="8ds-qj-G2Y"/>
+                                    <constraint firstItem="ZE1-1b-hch" firstAttribute="top" secondItem="h7P-pY-Gdm" secondAttribute="top" id="GdS-51-YeE"/>
+                                    <constraint firstItem="h7P-pY-Gdm" firstAttribute="leading" secondItem="ZE1-1b-hch" secondAttribute="leading" id="Qps-Wn-wrS"/>
+                                    <constraint firstItem="h7P-pY-Gdm" firstAttribute="bottom" secondItem="ZE1-1b-hch" secondAttribute="bottom" id="Rc3-4m-IQP"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="ZE1-1b-hch"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="PyD-MK-1En"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Hho-L2-Aw3"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="h7P-pY-Gdm" firstAttribute="centerX" secondItem="jBs-mE-f9q" secondAttribute="centerX" id="iVF-Bd-h1s"/>
-                            <constraint firstItem="h7P-pY-Gdm" firstAttribute="centerY" secondItem="jBs-mE-f9q" secondAttribute="centerY" id="oag-jR-QAF"/>
+                            <constraint firstItem="Hho-L2-Aw3" firstAttribute="bottom" secondItem="A94-MG-WzW" secondAttribute="bottom" id="SVx-Lz-VLI"/>
+                            <constraint firstItem="A94-MG-WzW" firstAttribute="top" secondItem="Hho-L2-Aw3" secondAttribute="top" id="fSe-wL-G4d"/>
+                            <constraint firstItem="Hho-L2-Aw3" firstAttribute="trailing" secondItem="A94-MG-WzW" secondAttribute="trailing" id="jnx-oa-Aya"/>
+                            <constraint firstItem="A94-MG-WzW" firstAttribute="leading" secondItem="Hho-L2-Aw3" secondAttribute="leading" id="vY9-en-GD0"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Events" id="fCx-1r-XiM"/>


### PR DESCRIPTION
Scrolling was needed in the Events page because the events that can be logger too many and they don't fit in an iPhone anymore.